### PR TITLE
Fix missing icon for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _Can be run using `npm run codetotal:beta`_
 - Global
 
 - Front-end
-
+  - Add missing icon for Java
 - Back-End
 
 ## [v0.5.0] - 2023-08-10

--- a/packages/app/src/languages/components/LanguageIcon.tsx
+++ b/packages/app/src/languages/components/LanguageIcon.tsx
@@ -2,13 +2,6 @@ import { Theme, Typography, useTheme } from "@mui/material";
 import { FC } from "react";
 import { ProgrammingLanguage } from "shared-types";
 import { makeStyles } from "tss-react/mui";
-import { ReactComponent as JavaIcon } from "../../assets/languages/java.svg";
-import { ReactComponent as TypescriptIcon } from "../../assets/languages/typescript.svg";
-
-const iconsMap: Record<string, FC<React.SVGProps<SVGSVGElement>>> = {
-  java: JavaIcon,
-  typescript: TypescriptIcon,
-};
 
 export const LanguageIcon: FC<LanguageIconProps> = ({
   language,
@@ -25,7 +18,6 @@ export const LanguageIcon: FC<LanguageIconProps> = ({
   // they require a background since when used with an img tag
   // colors can't be applied through css and we end up with a black colored icon
   const requiresBackground = isDarkmode && language.icon === "plain";
-  const SVGIcon = iconsMap[language.name];
 
   return (
     <span
@@ -34,17 +26,14 @@ export const LanguageIcon: FC<LanguageIconProps> = ({
         requiresBackground && classes.darkmode
       )}
     >
-      {SVGIcon ? (
-        <SVGIcon className={classes.img} />
-      ) : (
-        <img
-          src={`https://cdn.jsdelivr.net/gh/devicons/devicon/icons/${language.name?.toLowerCase()}/${language.name?.toLowerCase()}-${
-            language.icon
-          }.svg`}
-          className={classes.img}
-          alt="programming language icon"
-        />
-      )}
+      <img
+        src={`https://cdn.jsdelivr.net/gh/devicons/devicon/icons/${language.name?.toLowerCase()}/${language.name?.toLowerCase()}-${
+          language.icon
+        }.svg`}
+        className={classes.img}
+        alt="programming language icon"
+      />
+
       {withLabel && (
         <Typography component="span" variant="body2" fontWeight={600}>
           {language.displayName}

--- a/packages/backend/src/language-detection/supported-languages.json
+++ b/packages/backend/src/language-detection/supported-languages.json
@@ -14,7 +14,8 @@
   "csharp": { "name": "csharp", "displayName": "C#", "icon": "plain" },
   "java": {
     "name": "java",
-    "displayName": "Java"
+    "displayName": "Java",
+    "icon": "original"
   },
   "go": { "name": "go", "displayName": "Go", "icon": "original" },
   "kt": { "name": "kotlin", "displayName": "Kotlin", "icon": "original" },


### PR DESCRIPTION
`icon` property was missing in `java` under `supported-languages.json`