### PR TITLE
Display "snippet" in results page instead of md5: xxxx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Can be run using `npm run codetotal:beta`_
   - Add a report progress bar
   - Optimize new analysis dialog, drawer and linters list components' renders
   - Fix completed report receiving updates from ongoing analysis
+  - Display "snippet" in results page instead of md5: xxxx
   
 - Back-End
   - Bug fix: SBOM packages not showing up in report page. Async parsing of packages information in SBOM module

--- a/packages/app/src/report/components/header/ReportHeader.tsx
+++ b/packages/app/src/report/components/header/ReportHeader.tsx
@@ -25,7 +25,6 @@ export const ReportHeader: FC<ReportBannerProps> = ({ ready }) => {
     scoreColor,
     resourceType,
     resourceValue,
-    code: snippet,
     linters = [],
     lintersWithIssues,
     progress,
@@ -90,22 +89,17 @@ export const ReportHeader: FC<ReportBannerProps> = ({ ready }) => {
             valueClassName={classes.nowrap}
             dataCy="progress"
           />
-          {resourceType === AnalysisType.Snippet && !!snippet ? (
-            <ReportHeaderSection
-              label="Resource"
-              // DevSkim: ignore DS126858
-              value={`md5: ${resourceValue}`}
-              valueClassName={classes.resourceValue}
-              dataCy="resource-value"
-            />
-          ) : (
-            <ReportHeaderSection
-              label="Resource"
-              value={resourceValue || "-"}
-              valueClassName={classes.resourceValue}
-              dataCy="resource-value"
-            />
-          )}
+
+          <ReportHeaderSection
+            label="Resource"
+            value={
+              resourceType === AnalysisType.Snippet
+                ? "snippet"
+                : resourceValue || "-"
+            }
+            valueClassName={classes.resourceValue}
+            dataCy="resource-value"
+          />
 
           {!!language && (
             <ReportHeaderSection


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/oxsecurity/codetotal/assets/111698101/158d591d-eccb-4aea-908c-a892e8e7c430">
