### PR TITLE
Fix Safari not showing score component correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Can be run using `npm run codetotal:beta`_
   - Add a report progress bar
   - Optimize new analysis dialog, drawer and linters list components' renders
   - Fix completed report receiving updates from ongoing analysis
-  - Safari not showing Score component correctly #81
+  - Fix Safari not showing Score component correctly #81
   
 - Back-End
   - Bug fix: SBOM packages not showing up in report page. Async parsing of packages information in SBOM module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Can be run using `npm run codetotal:beta`_
   - Add a report progress bar
   - Optimize new analysis dialog, drawer and linters list components' renders
   - Fix completed report receiving updates from ongoing analysis
+  - Safari not showing Score component correctly #81
   
 - Back-End
   - Bug fix: SBOM packages not showing up in report page. Async parsing of packages information in SBOM module

--- a/packages/app/src/analysis/components/AnalysisInputForm.tsx
+++ b/packages/app/src/analysis/components/AnalysisInputForm.tsx
@@ -85,7 +85,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
         : `0px 0px 10px 10px #00000010`,
     width: "100%",
     marginInline: "auto",
-    minHeight: 280,
+    minHeight: 300,
   },
   tabsContainer: {
     borderBottom: 1,

--- a/packages/app/src/report/components/header/Score.tsx
+++ b/packages/app/src/report/components/header/Score.tsx
@@ -37,6 +37,7 @@ export const Score: FC<ScoreProps> = ({
         value={value}
         classes={{
           circle: classes.circle,
+          svg: classes.svg,
         }}
         sx={{ zIndex: 1 }}
         color="inherit"
@@ -48,6 +49,9 @@ export const Score: FC<ScoreProps> = ({
           size={size}
           value={100}
           className={classes.centerAbsolute}
+          classes={{
+            svg: classes.svg,
+          }}
           sx={{
             zIndex: 0,
             color: "#d9d9d9",
@@ -109,6 +113,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   label: {
     fontSize: theme.typography.caption.fontSize,
+  },
+  svg: {
+    width: "100%",
+    height: "100%",
   },
 }));
 


### PR DESCRIPTION
SVG elements inside the Score components were missing width/height. 

![image](https://github.com/oxsecurity/codetotal/assets/111698101/629decd4-c37d-4e01-bd5c-7ae9547bfbcd)
