### PR TITLE
92 SBOM page hyperlinks to npm pipy package home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Can be run using `npm run codetotal:beta`_
   - Add a report progress bar
   - Optimize new analysis dialog, drawer and linters list components' renders
   - Fix completed report receiving updates from ongoing analysis
-  - Add link to packages' registry in SNOM panel
+  - Add link to packages' registry in SBOM panel
   
 - Back-End
   - Bug fix: SBOM packages not showing up in report page. Async parsing of packages information in SBOM module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Can be run using `npm run codetotal:beta`_
   - Add a report progress bar
   - Optimize new analysis dialog, drawer and linters list components' renders
   - Fix completed report receiving updates from ongoing analysis
+  - Add link to packages' registry in SNOM panel
   
 - Back-End
   - Bug fix: SBOM packages not showing up in report page. Async parsing of packages information in SBOM module

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "packages/app"
       ],
       "dependencies": {
-        "shared-types": "^1.0.0"
+        "@ct/shared-types": "^1.0.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.6.1",
@@ -2123,6 +2123,18 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@ct/app": {
+      "resolved": "packages/app",
+      "link": true
+    },
+    "node_modules/@ct/backend": {
+      "resolved": "packages/backend",
+      "link": true
+    },
+    "node_modules/@ct/shared-types": {
+      "resolved": "packages/shared-types",
+      "link": true
     },
     "node_modules/@cypress/request": {
       "version": "2.88.12",
@@ -5334,10 +5346,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/app": {
-      "resolved": "packages/app",
-      "link": true
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -5858,10 +5866,6 @@
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
-    },
-    "node_modules/backend": {
-      "resolved": "packages/backend",
-      "link": true
     },
     "node_modules/backo2": {
       "version": "1.0.2",
@@ -14362,10 +14366,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/shared-types": {
-      "resolved": "packages/shared-types",
-      "link": true
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16477,8 +16477,10 @@
       }
     },
     "packages/app": {
+      "name": "@ct/app",
       "version": "0.0.0",
       "dependencies": {
+        "@ct/shared-types": "^1.0.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.13.5",
@@ -16495,7 +16497,6 @@
         "react-icons": "^4.10.1",
         "react-router-dom": "^6.13.0",
         "react-syntax-highlighter": "^15.5.0",
-        "shared-types": "^1.0.0",
         "tss-react": "^4.8.6",
         "zustand": "^4.3.8"
       },
@@ -16523,9 +16524,11 @@
       }
     },
     "packages/backend": {
+      "name": "@ct/backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ct/shared-types": "^1.0.0",
         "@supercharge/promise-pool": "^3.0.0",
         "@vscode/vscode-languagedetection": "^1.0.22",
         "axios": "^1.4.0",
@@ -16538,7 +16541,6 @@
         "md5": "^2.3.0",
         "multer": "^1.4.5-lts.1",
         "redis": "^4.6.7",
-        "shared-types": "^1.0.0",
         "ws": "^8.13.0"
       },
       "devDependencies": {
@@ -16559,6 +16561,7 @@
       }
     },
     "packages/shared-types": {
+      "name": "@ct/shared-types",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   "author": "Itay",
   "license": "ISC",
   "dependencies": {
-    "shared-types": "^1.0.0"
+    "@ct/shared-types": "^1.0.0"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "@ct/app",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -28,7 +28,7 @@
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.13.0",
     "react-syntax-highlighter": "^15.5.0",
-    "shared-types": "^1.0.0",
+    "@ct/shared-types": "^1.0.0",
     "tss-react": "^4.8.6",
     "zustand": "^4.3.8"
   },

--- a/packages/app/src/analysis/actions/analysis-actions.ts
+++ b/packages/app/src/analysis/actions/analysis-actions.ts
@@ -1,11 +1,11 @@
-import axios from "axios";
 import {
   Analysis,
   AnalysisType,
   FileAnalysis,
   RepoAnalysis,
   SnippetAnalysis,
-} from "shared-types";
+} from "@ct/shared-types";
+import axios from "axios";
 import { ApiUrl } from "../../common/utils/backend-url";
 import { AnalysisStore, AsyncState } from "../stores/analysis-store";
 

--- a/packages/app/src/analysis/actions/analysis-language-actions.ts
+++ b/packages/app/src/analysis/actions/analysis-language-actions.ts
@@ -1,4 +1,4 @@
-import { ProgrammingLanguage } from "shared-types";
+import { ProgrammingLanguage } from "@ct/shared-types";
 import { fetchDetect } from "../../languages/actions/detect-language-actions";
 import { AnalysisStore } from "../stores/analysis-store";
 
@@ -19,6 +19,8 @@ export const clearLanguages = () => {
   });
 };
 
-export const setUserSelectedLanguage = (newValue: ProgrammingLanguage | undefined) => {
-    AnalysisStore.setState({ userSelectedLanguage: newValue });
-}
+export const setUserSelectedLanguage = (
+  newValue: ProgrammingLanguage | undefined
+) => {
+  AnalysisStore.setState({ userSelectedLanguage: newValue });
+};

--- a/packages/app/src/analysis/components/AnalysisInputForm.tsx
+++ b/packages/app/src/analysis/components/AnalysisInputForm.tsx
@@ -1,6 +1,6 @@
+import { AnalysisType, OneOfValues } from "@ct/shared-types";
 import { Alert, Paper, Tab, Tabs, Theme } from "@mui/material";
 import { FC, useCallback } from "react";
-import { AnalysisType, OneOfValues } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { startAnalysis } from "../actions/analysis-actions";
 import { AnalysisStore, useAnalysisStore } from "../stores/analysis-store";

--- a/packages/app/src/analysis/components/AnalysisTabPanel.tsx
+++ b/packages/app/src/analysis/components/AnalysisTabPanel.tsx
@@ -1,6 +1,6 @@
+import { AnalysisType, OneOfValues } from "@ct/shared-types";
 import { Box } from "@mui/material";
 import { FC, PropsWithChildren } from "react";
-import { AnalysisType, OneOfValues } from "shared-types";
 
 export const AnalysisTabPanel: FC<PropsWithChildren<AnalysisTabPanelProps>> = (
   props

--- a/packages/app/src/analysis/stores/analysis-store.ts
+++ b/packages/app/src/analysis/stores/analysis-store.ts
@@ -1,4 +1,8 @@
-import { AnalysisType, OneOfValues, ProgrammingLanguage } from "shared-types";
+import {
+  AnalysisType,
+  OneOfValues,
+  ProgrammingLanguage,
+} from "@ct/shared-types";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/packages/app/src/common/SeverityBadge.tsx
+++ b/packages/app/src/common/SeverityBadge.tsx
@@ -1,10 +1,10 @@
+import { OneOfValues, Severity } from "@ct/shared-types";
 import { Theme, Typography } from "@mui/material";
 import { FC } from "react";
 import { BsExclamation } from "react-icons/bs";
 import { IoMdCheckmarkCircleOutline } from "react-icons/io";
 import { MdErrorOutline, MdOutlineWarningAmber } from "react-icons/md";
 import { TbUrgent } from "react-icons/tb";
-import { OneOfValues, Severity } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 
 export const SeverityBadge: FC<SeverityBadgeProps> = ({ severity }) => {

--- a/packages/app/src/languages/actions/detect-language-actions.ts
+++ b/packages/app/src/languages/actions/detect-language-actions.ts
@@ -1,6 +1,6 @@
+import { ProgrammingLanguage } from "@ct/shared-types";
 import axios from "axios";
 import debounce from "lodash-es/debounce";
-import { ProgrammingLanguage } from "shared-types";
 import { ApiUrl } from "../../common/utils/backend-url";
 import { LanguagesStore } from "../stores/languages-store";
 

--- a/packages/app/src/languages/actions/language-actions.ts
+++ b/packages/app/src/languages/actions/language-actions.ts
@@ -1,5 +1,5 @@
+import { ProgrammingLanguage } from "@ct/shared-types";
 import axios from "axios";
-import { ProgrammingLanguage } from "shared-types";
 import { ApiUrl } from "../../common/utils/backend-url";
 import { LanguagesStore } from "../stores/languages-store";
 

--- a/packages/app/src/languages/components/LanguageIcon.tsx
+++ b/packages/app/src/languages/components/LanguageIcon.tsx
@@ -1,6 +1,6 @@
+import { ProgrammingLanguage } from "@ct/shared-types";
 import { Theme, Typography, useTheme } from "@mui/material";
 import { FC } from "react";
-import { ProgrammingLanguage } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 
 export const LanguageIcon: FC<LanguageIconProps> = ({

--- a/packages/app/src/languages/components/LanguageSelector.tsx
+++ b/packages/app/src/languages/components/LanguageSelector.tsx
@@ -1,3 +1,4 @@
+import { ProgrammingLanguage } from "@ct/shared-types";
 import {
   Autocomplete,
   CircularProgress,
@@ -9,7 +10,6 @@ import {
   useTheme,
 } from "@mui/material";
 import React, { FC, SyntheticEvent, useCallback } from "react";
-import { ProgrammingLanguage } from "shared-types";
 import { loadAllLanguages } from "../actions/language-actions";
 import { useLanguagesStore } from "../stores/languages-store";
 import { LanguageIcon } from "./LanguageIcon";

--- a/packages/app/src/languages/stores/languages-store.ts
+++ b/packages/app/src/languages/stores/languages-store.ts
@@ -1,4 +1,4 @@
-import { ProgrammingLanguage } from "shared-types";
+import { ProgrammingLanguage } from "@ct/shared-types";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/packages/app/src/report/actions/init-report-action.ts
+++ b/packages/app/src/report/actions/init-report-action.ts
@@ -1,5 +1,5 @@
+import { AnalysisStatus } from "@ct/shared-types";
 import axios from "axios";
-import { AnalysisStatus } from "shared-types";
 import { ApiUrl } from "../../common/utils/backend-url";
 import { ReportStore } from "../stores/fe-report-store";
 import { subscribeToReportProgress } from "./subscribe-report-action";

--- a/packages/app/src/report/actions/selected-linter-actions.ts
+++ b/packages/app/src/report/actions/selected-linter-actions.ts
@@ -1,4 +1,4 @@
-import { Linter } from "shared-types";
+import { Linter } from "@ct/shared-types";
 import { ReportStore } from "../stores/fe-report-store";
 import { SelectedLinterStore } from "../stores/selected-linter-store";
 

--- a/packages/app/src/report/actions/subscribe-report-action.ts
+++ b/packages/app/src/report/actions/subscribe-report-action.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus, ReportState } from "shared-types";
+import { AnalysisStatus, ReportState } from "@ct/shared-types";
 import { ReportStore } from "../stores/fe-report-store";
 import { subscribe } from "../utils/ws-client";
 

--- a/packages/app/src/report/components/details/Details.tsx
+++ b/packages/app/src/report/components/details/Details.tsx
@@ -1,6 +1,6 @@
+import { AnalysisStatus, AnalysisType } from "@ct/shared-types";
 import { Paper, Theme, Typography } from "@mui/material";
 import { FC } from "react";
-import { AnalysisStatus, AnalysisType } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { Loader } from "../../../common/Loader";
 import { useReportStore } from "../../stores/fe-report-store";

--- a/packages/app/src/report/components/details/FileInfo.tsx
+++ b/packages/app/src/report/components/details/FileInfo.tsx
@@ -1,6 +1,6 @@
+import { FileDetails } from "@ct/shared-types";
 import { filesize } from "filesize";
 import { FC } from "react";
-import { FileDetails } from "shared-types";
 import { DetailsItem } from "./DetailsItem";
 
 export const FileInfo: FC<FileInfoProps> = ({ fileDetails }) => {

--- a/packages/app/src/report/components/details/RepoInfo.tsx
+++ b/packages/app/src/report/components/details/RepoInfo.tsx
@@ -1,6 +1,6 @@
+import { RepoDetails } from "@ct/shared-types";
 import { Theme, Typography } from "@mui/material";
 import { FC } from "react";
-import { RepoDetails } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { DetailsItem } from "./DetailsItem";
 

--- a/packages/app/src/report/components/detection/LinterListItem.tsx
+++ b/packages/app/src/report/components/detection/LinterListItem.tsx
@@ -1,6 +1,6 @@
+import { Linter } from "@ct/shared-types";
 import { ListItem, ListItemButton, Theme, Typography } from "@mui/material";
 import { FC, memo } from "react";
-import { Linter } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { selectLinter } from "../../actions/selected-linter-actions";
 import { LinterLogo } from "./LinterLogo";

--- a/packages/app/src/report/components/detection/LinterLogo.tsx
+++ b/packages/app/src/report/components/detection/LinterLogo.tsx
@@ -1,6 +1,6 @@
+import { Linter } from "@ct/shared-types";
 import { Theme, Typography } from "@mui/material";
 import { FC } from "react";
-import { Linter } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { ReactComponent as CheckovLogo } from "../../../assets/linters/checkov.svg";
 import { ReactComponent as DevSkimLogo } from "../../../assets/linters/devskim.svg";

--- a/packages/app/src/report/components/drawer/IssuesTable.tsx
+++ b/packages/app/src/report/components/drawer/IssuesTable.tsx
@@ -1,5 +1,5 @@
+import { Issue } from "@ct/shared-types";
 import { FC, useMemo } from "react";
-import { Issue } from "shared-types";
 import { ResponsiveTable, TableOptions } from "../../../common/ResponsiveTable";
 import { SeverityBadge } from "../../../common/SeverityBadge";
 

--- a/packages/app/src/report/components/header/ReportHeader.tsx
+++ b/packages/app/src/report/components/header/ReportHeader.tsx
@@ -1,3 +1,4 @@
+import { AnalysisType } from "@ct/shared-types";
 import {
   Divider,
   LinearProgress,
@@ -8,7 +9,6 @@ import {
   useTheme,
 } from "@mui/material";
 import { FC } from "react";
-import { AnalysisType } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { LanguageIcon } from "../../../languages/components/LanguageIcon";
 import { useReportStore } from "../../stores/fe-report-store";

--- a/packages/app/src/report/components/sbom/SBOM.tsx
+++ b/packages/app/src/report/components/sbom/SBOM.tsx
@@ -1,6 +1,6 @@
+import { AnalysisStatus } from "@ct/shared-types";
 import { Paper } from "@mui/material";
 import { FC } from "react";
-import { AnalysisStatus } from "shared-types";
 import { Loader } from "../../../common/Loader";
 import { useReportStore } from "../../stores/fe-report-store";
 import { SBOMTable } from "./SBOMTable";

--- a/packages/app/src/report/components/sbom/SBOMTable.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTable.tsx
@@ -3,6 +3,7 @@ import { SbomPackage } from "shared-types";
 import { ResponsiveTable, TableOptions } from "../../../common/ResponsiveTable";
 import { SeverityBadge } from "../../../common/SeverityBadge";
 import { useReportStore } from "../../stores/fe-report-store";
+import { SBOMTableNameCell } from "./SBOMTableNameCell";
 
 export const SBOMTable: FC = () => {
   const { packages } = useReportStore();
@@ -12,7 +13,10 @@ export const SBOMTable: FC = () => {
 const tableOptions: TableOptions<SbomPackage> = {
   emptyMessage: "No packages information found",
   cells: [
-    { label: "Name", key: "packageName" },
+    {
+      label: "Name",
+      cellRenderer: (row) => <SBOMTableNameCell pkg={row} />,
+    },
     { label: "Version", key: "packageVersion" },
     {
       label: "Severity",

--- a/packages/app/src/report/components/sbom/SBOMTable.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTable.tsx
@@ -23,7 +23,10 @@ const tableOptions: TableOptions<SbomPackage> = {
       cellRenderer: (row) => <SeverityBadge severity={row.severity} />,
     },
     { label: "License", key: "license" },
-    { label: "Registry", key: "registry" },
+    {
+      label: "Registry",
+      cellRenderer: (row) => row.registry || "Unknown",
+    },
     { label: "File Path", key: "filePath" },
   ],
 };

--- a/packages/app/src/report/components/sbom/SBOMTable.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTable.tsx
@@ -1,5 +1,5 @@
+import { SbomPackage } from "@ct/shared-types";
 import { FC } from "react";
-import { SbomPackage } from "shared-types";
 import { ResponsiveTable, TableOptions } from "../../../common/ResponsiveTable";
 import { SeverityBadge } from "../../../common/SeverityBadge";
 import { useReportStore } from "../../stores/fe-report-store";

--- a/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+import { SbomPackage } from "shared-types";
+import { makeStyles } from "tss-react/mui";
+import { resolveRegistryUrl } from "../../utils/registry-utils";
+
+export const SBOMTableNameCell: FC<SBOMTableNameCellProps> = ({ pkg }) => {
+  const { classes } = useStyles();
+  const registryUrl = resolveRegistryUrl(pkg);
+
+  if (!registryUrl) {
+    return pkg.packageName;
+  }
+
+  return (
+    <a
+      target="_blank"
+      rel="noreferrer"
+      href={registryUrl}
+      className={classes.invertedLink}
+    >
+      {pkg.packageName}
+    </a>
+  );
+};
+
+const useStyles = makeStyles()(() => ({
+  invertedLink: {
+    color: "inherit",
+  },
+}));
+
+interface SBOMTableNameCellProps {
+  pkg: SbomPackage;
+}

--- a/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
@@ -1,5 +1,7 @@
 import { SbomPackage } from "@ct/shared-types";
+import { Tooltip } from "@mui/material";
 import { FC } from "react";
+import { AiFillInfoCircle } from "react-icons/ai";
 import { makeStyles } from "tss-react/mui";
 import { resolveRegistryUrl } from "../../utils/registry-utils";
 
@@ -8,7 +10,20 @@ export const SBOMTableNameCell: FC<SBOMTableNameCellProps> = ({ pkg }) => {
   const registryUrl = resolveRegistryUrl(pkg);
 
   if (!registryUrl) {
-    return pkg.packageName;
+    return (
+      <span className={classes.missingRegistry}>
+        <span>{pkg.packageName}</span>
+        <Tooltip
+          arrow
+          placement="top"
+          title="Not found in the registry, could be an internal package"
+        >
+          <span style={{ display: "flex" }}>
+            <AiFillInfoCircle />
+          </span>
+        </Tooltip>
+      </span>
+    );
   }
 
   return (
@@ -23,9 +38,14 @@ export const SBOMTableNameCell: FC<SBOMTableNameCellProps> = ({ pkg }) => {
   );
 };
 
-const useStyles = makeStyles()(() => ({
+const useStyles = makeStyles()((theme) => ({
   invertedLink: {
     color: "inherit",
+  },
+  missingRegistry: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: theme.spacing(1),
   },
 }));
 

--- a/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
+++ b/packages/app/src/report/components/sbom/SBOMTableNameCell.tsx
@@ -1,5 +1,5 @@
+import { SbomPackage } from "@ct/shared-types";
 import { FC } from "react";
-import { SbomPackage } from "shared-types";
 import { makeStyles } from "tss-react/mui";
 import { resolveRegistryUrl } from "../../utils/registry-utils";
 

--- a/packages/app/src/report/fe-report-types.ts
+++ b/packages/app/src/report/fe-report-types.ts
@@ -1,4 +1,4 @@
-import { OneOfValues, Severity } from "shared-types";
+import { OneOfValues, Severity } from "@ct/shared-types";
 
 export enum ReportType {
   Detection,

--- a/packages/app/src/report/stores/fe-report-store.ts
+++ b/packages/app/src/report/stores/fe-report-store.ts
@@ -18,6 +18,7 @@ const initialState: InitialState = {
   analysisError: undefined,
   language: undefined,
   code: undefined,
+  fetchingSBOMPackages: false,
 };
 
 export const ReportStore = createStore<FeReportStoreState>((set, get) => ({

--- a/packages/app/src/report/stores/fe-report-store.ts
+++ b/packages/app/src/report/stores/fe-report-store.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus, Issue, ReportState } from "shared-types";
+import { AnalysisStatus, Issue, ReportState } from "@ct/shared-types";
 import { createStore, useStore } from "zustand";
 import { ScoreColorKey } from "../fe-report-types";
 import { resolveScoreColor } from "../utils/score-utils";

--- a/packages/app/src/report/stores/selected-linter-store.ts
+++ b/packages/app/src/report/stores/selected-linter-store.ts
@@ -1,4 +1,4 @@
-import { Linter } from "shared-types";
+import { Linter } from "@ct/shared-types";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/packages/app/src/report/utils/registry-utils.ts
+++ b/packages/app/src/report/utils/registry-utils.ts
@@ -1,4 +1,4 @@
-import { Registry, SbomPackage } from "shared-types";
+import { Registry, SbomPackage } from "@ct/shared-types";
 
 export const resolveRegistryUrl = ({
   packageName,

--- a/packages/app/src/report/utils/registry-utils.ts
+++ b/packages/app/src/report/utils/registry-utils.ts
@@ -1,0 +1,16 @@
+import { Registry, SbomPackage } from "shared-types";
+
+export const resolveRegistryUrl = ({
+  packageName,
+  packageVersion,
+  registry,
+}: SbomPackage) => {
+  switch (registry) {
+    case Registry.Npm:
+      return `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`;
+    case Registry.Pypi:
+      return `https://pypi.org/project/${packageName}/${packageVersion}`;
+  }
+
+  return undefined;
+};

--- a/packages/app/src/report/utils/ws-client.ts
+++ b/packages/app/src/report/utils/ws-client.ts
@@ -1,4 +1,4 @@
-import { ReportState } from "shared-types";
+import { ReportState } from "@ct/shared-types";
 import config from "../../config";
 
 export const subscribe = ({

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "@ct/backend",
   "version": "1.0.0",
   "description": "",
   "types": "./src/index.ts",
@@ -30,7 +30,7 @@
     "md5": "^2.3.0",
     "multer": "^1.4.5-lts.1",
     "redis": "^4.6.7",
-    "shared-types": "^1.0.0",
+    "@ct/shared-types": "^1.0.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/packages/backend/src/actions/create-analysis-request.ts
+++ b/packages/backend/src/actions/create-analysis-request.ts
@@ -1,6 +1,3 @@
-import axios from "axios";
-import FormData from "form-data";
-import md5 from "md5"; // DevSkim: ignore DS126858
 import {
   Analysis,
   AnalysisType,
@@ -8,7 +5,10 @@ import {
   RepoAnalysis,
   ReportState,
   SnippetAnalysis,
-} from "shared-types";
+} from "@ct/shared-types";
+import axios from "axios";
+import FormData from "form-data";
+import md5 from "md5"; // DevSkim: ignore DS126858
 import config from "../config";
 import { detectLanguage } from "../language-detection/language-detect";
 import { logger } from "../utils/logger";

--- a/packages/backend/src/actions/create-analysis.ts
+++ b/packages/backend/src/actions/create-analysis.ts
@@ -1,5 +1,5 @@
+import { Analysis } from "@ct/shared-types";
 import axios from "axios";
-import { Analysis } from "shared-types";
 import config from "../config";
 import { createReportStore } from "../stores/be-report-store";
 import { logger } from "../utils/logger";

--- a/packages/backend/src/http/handlers/analysis-http-handler.ts
+++ b/packages/backend/src/http/handlers/analysis-http-handler.ts
@@ -1,5 +1,5 @@
+import { Analysis, FileAnalysis } from "@ct/shared-types";
 import { Request, Response } from "express";
-import { Analysis, FileAnalysis } from "shared-types";
 import { createAnalysis } from "../../actions/create-analysis";
 import { logger } from "../../utils/logger";
 

--- a/packages/backend/src/http/handlers/report-http-handler.ts
+++ b/packages/backend/src/http/handlers/report-http-handler.ts
@@ -1,5 +1,5 @@
+import { AnalysisStatus } from "@ct/shared-types";
 import { Request, Response } from "express";
-import { AnalysisStatus } from "shared-types";
 import { getStore } from "../../stores/stores-map";
 
 export const reportHttpHandler = (req: Request, res: Response) => {

--- a/packages/backend/src/language-detection/language-detect.ts
+++ b/packages/backend/src/language-detection/language-detect.ts
@@ -1,4 +1,4 @@
-import { ProgrammingLanguage } from "shared-types";
+import { ProgrammingLanguage } from "@ct/shared-types";
 import { resolveId } from "./language-resolve-id";
 import supportedLanguages from "./supported-languages.json";
 

--- a/packages/backend/src/megalinter/megalinter-types.ts
+++ b/packages/backend/src/megalinter/megalinter-types.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus, LinterStatus } from "shared-types";
+import { AnalysisStatus, LinterStatus } from "@ct/shared-types";
 
 export enum MessageType {
   MegalinterStart = "megalinterStart",

--- a/packages/backend/src/megalinter/parsers/parse-details.ts
+++ b/packages/backend/src/megalinter/parsers/parse-details.ts
@@ -1,4 +1,4 @@
-import { AnalysisType, ReportState } from "shared-types";
+import { AnalysisType, ReportState } from "@ct/shared-types";
 import { ReportStore } from "../../stores/be-report-store";
 import { logger } from "../../utils/logger";
 import { BaseMessage } from "../megalinter-types";

--- a/packages/backend/src/megalinter/parsers/parse-linter-status.test.ts
+++ b/packages/backend/src/megalinter/parsers/parse-linter-status.test.ts
@@ -1,4 +1,4 @@
-import { LinterStatus } from "shared-types";
+import { LinterStatus } from "@ct/shared-types";
 import { LinterCompleteMessage } from "../megalinter-types";
 import { parseLinterStatus } from "./parse-linter-status";
 

--- a/packages/backend/src/megalinter/parsers/parse-megalinter-complete.test.ts
+++ b/packages/backend/src/megalinter/parsers/parse-megalinter-complete.test.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus } from "shared-types";
+import { AnalysisStatus } from "@ct/shared-types";
 import { MegalinterCompleteMessage } from "../megalinter-types";
 import { parseMegalinterComplete } from "./parse-megalinter-complete";
 

--- a/packages/backend/src/megalinter/parsers/parse-megalinter-complete.ts
+++ b/packages/backend/src/megalinter/parsers/parse-megalinter-complete.ts
@@ -1,5 +1,6 @@
 import { AnalysisStatus } from "@ct/shared-types";
 import { ReportStore } from "../../stores/be-report-store";
+import { logger } from "../../utils/logger";
 import { MegalinterCompleteMessage } from "../megalinter-types";
 
 export const parseMegalinterComplete = (
@@ -7,10 +8,27 @@ export const parseMegalinterComplete = (
   reportStore: ReportStore
 ) => {
   const { megaLinterStatus } = msg;
-  if (
-    megaLinterStatus === AnalysisStatus.Created ||
-    megaLinterStatus === AnalysisStatus.Completed
-  ) {
-    reportStore.set({ status: megaLinterStatus });
+
+  switch (megaLinterStatus) {
+    case AnalysisStatus.Created:
+      if (megaLinterStatus === AnalysisStatus.Created) {
+        reportStore.set({ status: megaLinterStatus });
+      }
+      break;
+    case AnalysisStatus.Completed:
+      if (reportStore.get().fetchingSBOMPackages) {
+        logger.megalinter.log(
+          "Megalinter completed, waiting for SBOM packages to complete"
+        );
+        reportStore.subscribe((state) => {
+          if (state.fetchingSBOMPackages === false) {
+            reportStore.set({ status: AnalysisStatus.Completed });
+          }
+        });
+      } else {
+        reportStore.set({ status: AnalysisStatus.Completed });
+      }
+      break;
+    // error status is handled by a different parser
   }
 };

--- a/packages/backend/src/megalinter/parsers/parse-megalinter-complete.ts
+++ b/packages/backend/src/megalinter/parsers/parse-megalinter-complete.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus } from "shared-types";
+import { AnalysisStatus } from "@ct/shared-types";
 import { ReportStore } from "../../stores/be-report-store";
 import { MegalinterCompleteMessage } from "../megalinter-types";
 

--- a/packages/backend/src/megalinter/parsers/parse-megalinter-start.test.ts
+++ b/packages/backend/src/megalinter/parsers/parse-megalinter-start.test.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus, LinterStatus } from "shared-types";
+import { AnalysisStatus, LinterStatus } from "@ct/shared-types";
 import {
   MegalinterStartMessage,
   MessageType,

--- a/packages/backend/src/megalinter/parsers/parse-megalinter-start.ts
+++ b/packages/backend/src/megalinter/parsers/parse-megalinter-start.ts
@@ -1,4 +1,4 @@
-import { LinterStatus } from "shared-types";
+import { LinterStatus } from "@ct/shared-types";
 import { ReportStore } from "../../stores/be-report-store";
 import { logger } from "../../utils/logger";
 import {

--- a/packages/backend/src/megalinter/parsers/parse-sarif.ts
+++ b/packages/backend/src/megalinter/parsers/parse-sarif.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { Issue, OneOfValues, Severity } from "shared-types";
+import { Issue, OneOfValues, Severity } from "@ct/shared-types";
 import { BaseMessage } from "../megalinter-types";
 
 export const parseSarif = (msg: any) => {

--- a/packages/backend/src/megalinter/parsers/parse-sbom.ts
+++ b/packages/backend/src/megalinter/parsers/parse-sbom.ts
@@ -1,4 +1,4 @@
-import { SbomPackage } from "shared-types";
+import { SbomPackage } from "@ct/shared-types";
 import { fetchPackages } from "../../sbom/sbom-fetching-utils";
 import { Component, Dependency } from "../../sbom/sbom-types";
 import {

--- a/packages/backend/src/megalinter/parsers/parse-sbom.ts
+++ b/packages/backend/src/megalinter/parsers/parse-sbom.ts
@@ -19,6 +19,7 @@ export const parseSBOM = async (
       msg?.outputSarif?.runs.length > 0 &&
       msg.outputSarif.runs[0]?.properties?.megalinter?.sbom
     ) {
+      reportStore.set({ fetchingSBOMPackages: true });
       console.log("parsing sbom...");
 
       const components = msg.outputSarif.runs[0].properties.megalinter.sbom
@@ -27,7 +28,7 @@ export const parseSBOM = async (
         .dependencies as Dependency[];
       const applications = extractMappingForApplication(components);
       const pkgsInfo = await fetchPackages(dependencies, components);
-      const sbomPackages: SbomPackage[] = await getPackages(
+      const sbomPackages: SbomPackage[] = getPackages(
         dependencies,
         components,
         applications,
@@ -36,6 +37,7 @@ export const parseSBOM = async (
       if (sbomPackages && sbomPackages.length > 0) {
         reportStore.set({ packages: sbomPackages });
       }
+      reportStore.set({ fetchingSBOMPackages: false });
     }
   }
 };

--- a/packages/backend/src/sbom/sbom-fetching-utils.ts
+++ b/packages/backend/src/sbom/sbom-fetching-utils.ts
@@ -7,7 +7,7 @@ import config from "../config";
 
 export const fetchPackages = async (
   dependencies: Dependency[],
-  components: Component[]
+  components: Component[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any[]> => {
   // filter out deps without "dependsOn"

--- a/packages/backend/src/sbom/sbom-utils.ts
+++ b/packages/backend/src/sbom/sbom-utils.ts
@@ -1,4 +1,4 @@
-import { Registry, SbomPackage, Severity } from "shared-types";
+import { Registry, SbomPackage, Severity } from "@ct/shared-types";
 import { logger } from "../utils/logger";
 import licenseConfig from "./licenseConfig.json";
 import { isNpmPackage, isPythonPackage } from "./sbom-fetching-utils";

--- a/packages/backend/src/sbom/sbom-utils.ts
+++ b/packages/backend/src/sbom/sbom-utils.ts
@@ -8,7 +8,7 @@ function sortByLicenseLength(arr: LicenseInfo[]): LicenseInfo[] {
   return arr.sort((a, b) => b.license.length - a.license.length);
 }
 
-export async function getPackages(
+export function getPackages(
   dependencies: Dependency[],
   components: Component[],
   applications: Record<string, string>,
@@ -38,7 +38,6 @@ export async function getPackages(
           const sourceList: string[] = [];
 
           if (isPythonPackage(purl)) {
-            registry = Registry.Pypi;
             try {
               const packageInfo = pkgsInfo.find(
                 (pkg) =>
@@ -52,11 +51,11 @@ export async function getPackages(
               if (packageInfo?.info?.classifiers) {
                 sourceList.push(packageInfo.info.classifiers.join(" "));
               }
+              registry = packageInfo ? Registry.Pypi : undefined;
             } catch (error) {
               logger.sbom.error("Error:", error.message);
             }
           } else if (isNpmPackage(purl)) {
-            registry = Registry.Npm;
             try {
               const packageInfo = pkgsInfo.find(
                 (pkg) =>
@@ -75,6 +74,7 @@ export async function getPackages(
               } else {
                 logger.sbom.log(`missing license for: ${purl}`);
               }
+              registry = packageInfo ? Registry.Npm : undefined;
             } catch (error) {
               logger.sbom.error(error);
             }

--- a/packages/backend/src/sbom/sbom-utils.ts
+++ b/packages/backend/src/sbom/sbom-utils.ts
@@ -1,4 +1,4 @@
-import { SbomPackage, Severity } from "shared-types";
+import { Registry, SbomPackage, Severity } from "shared-types";
 import { logger } from "../utils/logger";
 import licenseConfig from "./licenseConfig.json";
 import { isNpmPackage, isPythonPackage } from "./sbom-fetching-utils";
@@ -31,17 +31,18 @@ export async function getPackages(
         const component = components.find(
           (component) => component.purl === purl
         );
-        let registry = "";
+        let registry: Registry = undefined;
         let license = "Unknown";
         let severity = Severity.Medium;
         if (component) {
           const sourceList: string[] = [];
 
           if (isPythonPackage(purl)) {
-            registry = "PyPi";
+            registry = Registry.Pypi;
             try {
               const packageInfo = pkgsInfo.find(
-                (pkg) => pkg &&
+                (pkg) =>
+                  pkg &&
                   pkg.name === component.name &&
                   pkg.version === component.version
               );
@@ -55,9 +56,11 @@ export async function getPackages(
               logger.sbom.error("Error:", error.message);
             }
           } else if (isNpmPackage(purl)) {
+            registry = Registry.Npm;
             try {
               const packageInfo = pkgsInfo.find(
-                (pkg) => pkg &&
+                (pkg) =>
+                  pkg &&
                   pkg.name === component.name &&
                   pkg.version === component.version
               );
@@ -80,7 +83,7 @@ export async function getPackages(
           }
 
           if (sourceList.length == 0) {
-            logger.sbom.log(`no where to get license for ${purl}`);
+            logger.sbom.log(`nowhere to get license for ${purl}`);
           } else {
             for (const licenseSoruce of sourceList) {
               const licenseItem = sortedLicenseConfig.find((item) =>
@@ -97,10 +100,10 @@ export async function getPackages(
           sbomPackages.push({
             packageName: component.name,
             packageVersion: component.version,
-            license: license,
-            registry: registry,
-            severity: severity,
-            filePath: filePath,
+            license,
+            registry,
+            severity,
+            filePath,
           });
         } else {
           logger.sbom.log(`missing component info, purl: ${purl}`);
@@ -113,7 +116,13 @@ export async function getPackages(
 
   // Remove duplicates
   const sbomPackagesUnique = sbomPackages.reduce((unique, o) => {
-    if (!unique.some(obj => obj.packageName === o.packageName && obj.packageVersion === o.packageVersion)) {
+    if (
+      !unique.some(
+        (obj) =>
+          obj.packageName === o.packageName &&
+          obj.packageVersion === o.packageVersion
+      )
+    ) {
       unique.push(o);
     }
     return unique;
@@ -121,22 +130,21 @@ export async function getPackages(
 
   // Order SBOM packages
   const severityOrder = ["critical", "high", "medium", "low"];
-  sbomPackagesUnique.sort(
-    (a, b) => {
-      // First, order by severity
-      const orderRes = severityOrder.indexOf(b.severity) - severityOrder.indexOf(a.severity);
-      if (orderRes !== 0) {
-        return orderRes;
-      }
-      // Then order by package name
-      const packageNameRes = a.packageName.localeCompare(b.packageName);
-      if ([1, -1].includes(packageNameRes)) {
-        return packageNameRes;
-      }
-      // Otherwise use version number
-      return a.packageVersion.localeCompare(b.packageVersion);
+  sbomPackagesUnique.sort((a, b) => {
+    // First, order by severity
+    const orderRes =
+      severityOrder.indexOf(b.severity) - severityOrder.indexOf(a.severity);
+    if (orderRes !== 0) {
+      return orderRes;
     }
-  );
+    // Then order by package name
+    const packageNameRes = a.packageName.localeCompare(b.packageName);
+    if ([1, -1].includes(packageNameRes)) {
+      return packageNameRes;
+    }
+    // Otherwise use version number
+    return a.packageVersion.localeCompare(b.packageVersion);
+  });
   return sbomPackagesUnique;
 }
 

--- a/packages/backend/src/stores/be-report-store.test.ts
+++ b/packages/backend/src/stores/be-report-store.test.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus } from "shared-types";
+import { AnalysisStatus } from "@ct/shared-types";
 import { createReportStore } from "./be-report-store";
 import { getStore } from "./stores-map";
 

--- a/packages/backend/src/stores/be-report-store.ts
+++ b/packages/backend/src/stores/be-report-store.ts
@@ -1,4 +1,4 @@
-import { AnalysisStatus, ReportState } from "shared-types";
+import { AnalysisStatus, ReportState } from "@ct/shared-types";
 import { logger } from "../utils/logger";
 import { Store, createStore } from "./store";
 import { addStore } from "./stores-map";

--- a/packages/backend/src/stores/be-report-store.ts
+++ b/packages/backend/src/stores/be-report-store.ts
@@ -18,6 +18,7 @@ export const createReportStore = (requestId: string) => {
     score: 0,
     analysisError: undefined,
     code: undefined,
+    fetchingSBOMPackages: false,
   });
 
   // save the store instance for later use

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shared-types",
+  "name": "@ct/shared-types",
   "version": "1.0.0",
   "main": "./dist/index.js",
   "module": "./src/index.ts",

--- a/packages/shared-types/src/report-types.ts
+++ b/packages/shared-types/src/report-types.ts
@@ -83,7 +83,12 @@ export interface SbomPackage {
   packageName: string;
   packageVersion: string;
   license: string;
-  registry: string;
+  registry: Registry;
   severity: OneOfValues<typeof Severity>;
   filePath: string;
+}
+
+export enum Registry {
+  Npm = "npm",
+  Pypi = "pypi",
 }

--- a/packages/shared-types/src/report-types.ts
+++ b/packages/shared-types/src/report-types.ts
@@ -19,6 +19,7 @@ export interface ReportState {
   };
   language?: ProgrammingLanguage;
   code?: string;
+  fetchingSBOMPackages: boolean;
 }
 
 export interface RepoDetails {
@@ -83,7 +84,7 @@ export interface SbomPackage {
   packageName: string;
   packageVersion: string;
   license: string;
-  registry: Registry;
+  registry?: Registry;
   severity: OneOfValues<typeof Severity>;
   filePath: string;
 }


### PR DESCRIPTION
- Add link to packages registry
- Internal packages won't link to registry and will get a notice (see screenshot)
- Also, scope our internal packages to avoid `dependency-confusion-attack`. shared types -> @ct/shared-types


<img width="1439" alt="image" src="https://github.com/oxsecurity/codetotal/assets/111698101/ac6cd3bc-c05c-4194-b087-f89ec8c1c90e">